### PR TITLE
Provide empty presetting of $GLOBALS[TL_CONFIG][avatar_dir] for Contao 3.1

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,6 +9,11 @@
  */
 
 /**
+ * Presettings
+ */
+$GLOBALS['TL_CONFIG']['avatar_dir'] = '';
+
+/**
  * Back end form fields
  */
 $GLOBALS['BE_FFL']['avatar'] = 'Avatar\Widget\AvatarFileUpload';


### PR DESCRIPTION
Otherwise it will break up, when changing the avatar directory in the system settings with a bad request.
see https://github.com/contao/core/blob/develop/system/modules/core/classes/Ajax.php#L265
