### PR TITLE
Introducing feature to set a different preview size in FE

### DIFF
--- a/src/library/Avatar/AvatarWidget.php
+++ b/src/library/Avatar/AvatarWidget.php
@@ -33,6 +33,13 @@ class AvatarWidget extends \Widget implements \uploadable
     protected $strTemplate = 'form_avatar';
 
     /**
+     * Avatar preview size
+     *
+     * @var array
+     */
+    protected $arrAvatarPreviewSize = array();
+
+    /**
      * Submit user input
      *
      * @var boolean
@@ -65,6 +72,10 @@ class AvatarWidget extends \Widget implements \uploadable
                 if ($varValue > 0) {
                     $this->arrAttributes['size'] = $varValue;
                 }
+                break;
+
+            case 'avatarPreviewSize':
+                $this->arrAvatarPreviewSize = $varValue;
                 break;
 
             default:
@@ -315,6 +326,7 @@ class AvatarWidget extends \Widget implements \uploadable
         $this->maxlength  = $GLOBALS['TL_CONFIG']['avatar_maxsize'];
         $this->extensions = $GLOBALS['TL_CONFIG']['avatar_filetype'];
         $arrImage         = deserialize($GLOBALS['TL_CONFIG']['avatar_maxdims']);
+        $arrPreviewImage  = $this->arrAvatarPreviewSize ?: $arrImage;
 
         $this->import('FrontendUser', 'User');
 
@@ -331,24 +343,24 @@ class AvatarWidget extends \Widget implements \uploadable
         if ($objFile !== null) {
             $template .= '<img src="' . TL_FILES_URL . \Image::get(
                     $objFile->path,
-                    $arrImage[0],
-                    $arrImage[1],
-                    $arrImage[2]
-                ) . '" width="' . $arrImage[0] . '" height="' . $arrImage[1] . '" alt="' . $strAlt . '" class="avatar">';
+                    $arrPreviewImage[0],
+                    $arrPreviewImage[1],
+                    $arrPreviewImage[2]
+                ) . '" width="' . $arrPreviewImage[0] . '" height="' . $arrPreviewImage[1] . '" alt="' . $strAlt . '" class="avatar">';
         } elseif ($this->User->gender != '') {
             $template .= '<img src="' . TL_FILES_URL . \Image::get(
                     "system/modules/avatar/assets/" . $this->User->gender . ".png",
-                    $arrImage[0],
-                    $arrImage[1],
-                    $arrImage[2]
-                ) . '" width="' . $arrImage[0] . '" height="' . $arrImage[1] . '" alt="Avatar" class="avatar">';
+                    $arrPreviewImage[0],
+                    $arrPreviewImage[1],
+                    $arrPreviewImage[2]
+                ) . '" width="' . $arrPreviewImage[0] . '" height="' . $arrPreviewImage[1] . '" alt="Avatar" class="avatar">';
         } else {
             $template .= '<img src="' . TL_FILES_URL . \Image::get(
                     "system/modules/avatar/assets/male.png",
-                    $arrImage[0],
-                    $arrImage[1],
-                    $arrImage[2]
-                ) . '" width="' . $arrImage[0] . '" height="' . $arrImage[1] . '" alt="Avatar" class="avatar">';
+                    $arrPreviewImage[0],
+                    $arrPreviewImage[1],
+                    $arrPreviewImage[2]
+                ) . '" width="' . $arrImage[0] . '" height="' . $arrPreviewImage[1] . '" alt="Avatar" class="avatar">';
         }
 
         $template .= sprintf(


### PR DESCRIPTION
Ich brauchte die Möglichkeit, die Vorschaugrösse des Avatars im Modul "Persönliche Daten" anzupassen. Wenn ich 600 x 600 Pixel erlauben wollte, wurde das automatisch so riesig dargestellt. Jetzt kann man mittels

``` php
$GLOBALS['TL_DCA']['tl_member']['fields']['avatar']['eval']['avatarPreviewSize'] = array(100, 100, 'proportional');
```

zwar 600 x 600 für den Upload erlauben, aber nur 100 x 100 als Vorschaubild anzeigen.
