### PR TITLE
Fixed overriding avatar settings

### DIFF
--- a/src/library/Avatar/AvatarWidget.php
+++ b/src/library/Avatar/AvatarWidget.php
@@ -44,7 +44,7 @@ class AvatarWidget extends \Widget implements \uploadable
      *
      * @var boolean
      */
-    protected $blnSubmitInput = true;
+    protected $blnSubmitInput = false;
 
     /**
      * Add specific attributes


### PR DESCRIPTION
Du speicherst in der validate den Avatar selber im Modul anstatt `$this->varValue` zu setzen. So speicherst du zwar den korrekten Wert in das MemberModel, allerdings wird es dann gleich wieder überschrieben, weil Contao ja den Value des Formularfelds speichert. So wird das Widget nicht abgeschickt (muss man auch nicht weil du's ja schon speicherst). Das fixt zwar den Bug, aber trotzdem sollte man es schöner lösen :D
