### PR TITLE
Write the file UUID back to Widget::$varValue.

### DIFF
--- a/src/library/Avatar/AvatarWidget.php
+++ b/src/library/Avatar/AvatarWidget.php
@@ -301,6 +301,8 @@ class AvatarWidget extends \Widget implements \uploadable
                     $objMember->avatar = $objModel->uuid;
                     $objMember->save();
 
+                    $this->varValue = $objModel->uuid;
+
                     $this->log(
                         'File "' . $targetName . '" has been moved to "' . $strUploadFolder . '"',
                         __METHOD__,


### PR DESCRIPTION
This allow usage of the widget in the personal data form and maybe other forms that use the $widget->value in further processing.
