### PR TITLE
Added insert tag paramter for backend users

### DIFF
--- a/src/library/Avatar/InsertTags.php
+++ b/src/library/Avatar/InsertTags.php
@@ -88,7 +88,12 @@ class InsertTags extends \System
 		}
 
 		// search the member record
-		$objMember = \MemberModel::findByPk($arrTag[1]);
+		if($arrTag[2] == 'be')
+        {
+            $objMember = \UserModel::findById($arrTag[1]);
+        } else {
+            $objMember = \MemberModel::findByPk($arrTag[1]);
+        }
 
 		// return anonymous avatar, if member not found
 		if (!$objMember) {

--- a/src/library/Avatar/InsertTags.php
+++ b/src/library/Avatar/InsertTags.php
@@ -88,12 +88,11 @@ class InsertTags extends \System
 		}
 
 		// search the member record
-		if($arrTag[2] == 'be')
-        {
-            $objMember = \UserModel::findById($arrTag[1]);
-        } else {
-            $objMember = \MemberModel::findByPk($arrTag[1]);
-        }
+		if($arrTag[2] == 'be') {
+            		$objMember = \UserModel::findById($arrTag[1]);
+        	} else {
+            		$objMember = \MemberModel::findByPk($arrTag[1]);
+        	}
 
 		// return anonymous avatar, if member not found
 		if (!$objMember) {


### PR DESCRIPTION
Hi Kirsten,
in the description of the extension on http://de.contaowiki.org/Avatar I read that you can insert avatars of backend users too. 

I wondered why {{avatar::1::be}} did not work and recognized that you have removed this functionality. If I haven't missed anything, it would be really simple to add this functionality again. What do you think?

Best regards,
Sascha
